### PR TITLE
Remove espresso from prod dependency

### DIFF
--- a/mobile-engage-sdk/build.gradle
+++ b/mobile-engage-sdk/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     compile "com.android.support:support-annotations:26.1.0"
     compile 'com.google.firebase:firebase-core:16.0.6'
     compile 'com.google.firebase:firebase-messaging:17.3.4'
-    compile('com.android.support.test.espresso:espresso-idling-resource:2.2.2')
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.12.0'


### PR DESCRIPTION
I suppose there is no good reason to embed an Android test library in the production code.
I've not tested this change, I don't know if there could be some some hidden impacts, so please review carefully, thanks ;)